### PR TITLE
Fix: install SDK on Github Actions the local version

### DIFF
--- a/.github/workflows/run_local_test.yml
+++ b/.github/workflows/run_local_test.yml
@@ -20,7 +20,8 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies  
         run: |  
-          python -m pip install --upgrade pip  
+          python -m pip install --upgrade pip
+          python -m pip install .
           python -m pip install -r requirements.txt
       - name: Lint with Ruff  
         run: |  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-digitalhub[full]==0.8.0b2
 flake8
 pytest
 pytest-cov


### PR DESCRIPTION
## Features:
* Remove digital hub from requirements.txt;
* Add pip install of the SDK using the branch's local files.